### PR TITLE
Toniof xxx defrosting

### DIFF
--- a/xcube_places_plugin/api/context.py
+++ b/xcube_places_plugin/api/context.py
@@ -32,6 +32,7 @@ from xcube.server.api import Context
 from xcube.webapi.places import PlacesContext
 from xcube.webapi.places.context import PlaceGroup
 from xcube_geodb.core.geodb import GeoDBClient
+from xcube.util.frozen import Frozen
 
 
 class PlacesPluginContext(ApiContext):
@@ -125,6 +126,8 @@ class PlacesPluginContext(ApiContext):
     def _run_queries(self) -> List[GeoDataFrame]:
         gdfs = []
         for place_group in self.config.get('GeoDBConf').get('PlaceGroups'):
+            if isinstance(place_group, Frozen):
+                place_group = place_group.defrost()
             query = place_group.get('Query')
             dn = query.split('?')[0]
             db_name = dn.split('_')[0]

--- a/xcube_places_plugin/api/context.py
+++ b/xcube_places_plugin/api/context.py
@@ -70,7 +70,7 @@ class PlacesPluginContext(ApiContext):
             for k in gdf.attrs.keys():
                 place_group_config[k] = gdf.attrs[k]
             place_group = self._create_place_group(place_group_config, gdf)
-            dataset_ids = place_group_config['DatasetRefs']
+            dataset_ids = place_group_config.get('DatasetRefs', [])
             self._places_ctx.add_place_group(place_group, dataset_ids)
         LOG.debug('...done.')
 

--- a/xcube_places_plugin/version.py
+++ b/xcube_places_plugin/version.py
@@ -20,4 +20,4 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3.dev0'


### PR DESCRIPTION
xcube "freezes" configuration dictionaries using its xcube.util.frozen module. These FrozenLists and FrozenDicts cannot be written to json, which is a step required for the plugin to work. In this pull request, it is checked whether a dictionary is Frozen, and if it is, it is defrosted.